### PR TITLE
avoids copying the content to the root extensions folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Simply follow the instructions and everything should be fine :
     # Get the last released version
 	git checkout 1.4
     # copy to extensions directory
-    cp -r pixel-saver@deadalnix.me ~/.local/share/gnome-shell/extensions
+    cp -r pixel-saver@deadalnix.me -t ~/.local/share/gnome-shell/extensions
     # activate
     gnome-shell-extension-tool -e pixel-saver@deadalnix.me
 


### PR DESCRIPTION
If an user does not have the directory `~/.local/share/gnome-shell/extensions` created, the original `cp` command is gonna copy the **content** of the folder `pixel-saver@deadalnix.me` into `extensions`, instead of the **folder** itself