### PR TITLE
Updated label.set_text() for 3.16

### DIFF
--- a/pixel-saver@deadalnix.me/app_menu.js
+++ b/pixel-saver@deadalnix.me/app_menu.js
@@ -37,7 +37,7 @@ function updateAppMenu() {
 	}
 	
 	LOG('Override title ' + title);
-	appMenu._label.setText(title);
+	appMenu._label.set_text(title);
 	tooltip.text = title;
 	
 	return false;


### PR DESCRIPTION
The function for setting the appMenu label text has changed name for 3.16.

The old function name doesn't work anymore and throws the following error:
> Gjs-WARNING **: JS ERROR: TypeError: appMenu._label.setText is not a function
> updateAppMenu@/usr/share/gnome-shell/extensions/pixel-saver@deadalnix.me/app_menu.js:41

This error was also referred to in deadalnix/pixel-saver#21