### PR TITLE
Add a condition to handle cases when act['x-window'] is undefined.

### DIFF
--- a/pixel-saver@deadalnix.me/decoration.js
+++ b/pixel-saver@deadalnix.me/decoration.js
@@ -48,7 +48,7 @@ function guessWindowXID(win) {
 	
 	// use xwininfo, take first child.
 	let act = win.get_compositor_private();
-	if (act) {
+	if (act && act['x-window']) {
 		let xwininfo = GLib.spawn_command_line_sync('xwininfo -children -id 0x%x'.format(act['x-window']));
 		if (xwininfo[0]) {
 			let str = xwininfo[1].toString();


### PR DESCRIPTION
see : https://github.com/deadalnix/pixel-saver/issues/14