### PR TITLE
Gnome 3.16 compatibility, related issue #21.

### DIFF
--- a/pixel-saver@deadalnix.me/app_menu.js
+++ b/pixel-saver@deadalnix.me/app_menu.js
@@ -111,7 +111,7 @@ function onAppMenuHover(actor) {
 				WARN('showTooltip is false and delay callback ran.');
 			}
 			
-			let label = appMenu._label._label;
+			let label = appMenu._label;
 			
 			if(!label.get_clutter_text().get_layout().is_ellipsized()) {
 				// Do not need to hide.


### PR DESCRIPTION
At gnome 3.16 appMenu._label._label is undefined, the current master is not
backward compatible, so I just make the changes without other considerations.