### PR TITLE
Mention xprop as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Simply follow the instructions and everything should be fine :
     # activate
     gnome-shell-extension-tool -e pixel-saver@deadalnix.me
 
+### Dependencies
+
+Pixel Saver depends on Xorg's xprop utility.
+
 Configuration
 -------------
 


### PR DESCRIPTION
I've added Pixel Saver to a fresh Arch install with Gnome 3.16 and noticed it wasn't working.

Looking glass reported that Pixel Saver failed to invoke xprop. My guess is that xprop doesn't come installed by default on some distributions so I've added a small section to the README mentioning that Pixel Saver depends on xprop.