### PR TITLE
Handle windows with titles that have special characters by searching active windows

### DIFF
--- a/pixel-saver@deadalnix.me/decoration.js
+++ b/pixel-saver@deadalnix.me/decoration.js
@@ -87,22 +87,20 @@ function guessWindowXID(win) {
 		for (var i = 0; i < windowList.length; ++i) {
 			let cmd = 'xprop -id "' + windowList[i] + '" _NET_WM_NAME _PIXEL_SAVER_ORIGINAL_STATE';
 			let result = GLib.spawn_command_line_sync(cmd);
-			LOG(cmd)
+			LOG(cmd);
 
 			if (result[0]) {
 				let output = result[1].toString();
 				let isManaged = output.indexOf("_PIXEL_SAVER_ORIGINAL_STATE(CARDINAL)") > -1;
-
 				if (isManaged) {
 					continue;
 				}
 
-				let title = output.substring(output.indexOf('"') + 1, output.length - 2);
-
-				LOG("Title of XID %s is \"%s\".".format(windowList[i], title));
+				let title = output.match(/_NET_WM_NAME(\(\w+\))? = "(([^\\"]|\\"|\\\\)*)"/);
+				LOG("Title of XID %s is \"%s\".".format(windowList[i], title[2]));
 
 				// Is this our guy?
-				if (title == win.title) {
+				if (title && title[2] == win.title) {
 					return windowList[i];
 				}
 			}

--- a/pixel-saver@deadalnix.me/decoration.js
+++ b/pixel-saver@deadalnix.me/decoration.js
@@ -85,12 +85,18 @@ function guessWindowXID(win) {
 
 		// For each window ID, check if the title matches the desired title.
 		for (var i = 0; i < windowList.length; ++i) {
-			let cmd = 'xprop -id "' + windowList[i] + '" _NET_WM_NAME';
+			let cmd = 'xprop -id "' + windowList[i] + '" _NET_WM_NAME _PIXEL_SAVER_ORIGINAL_STATE';
 			let result = GLib.spawn_command_line_sync(cmd);
 			LOG(cmd)
 
 			if (result[0]) {
 				let output = result[1].toString();
+				let isManaged = output.indexOf("_PIXEL_SAVER_ORIGINAL_STATE(CARDINAL)") > -1;
+
+				if (isManaged) {
+					continue;
+				}
+
 				let title = output.substring(output.indexOf('"') + 1, output.length - 2);
 
 				LOG("Title of XID %s is \"%s\".".format(windowList[i], title));


### PR DESCRIPTION
This adds a third method for guessing a window's ID by using `xprop` to list all client windows and trying to match each window's title to the title of the given meta window. Sort of hacky, but gets the job done.

This might cause a problem if you have multiple windows open with the same title before the extension loads. Not sure if it needs handled, since the special character windows will likely be a lower occurrence and probably will have unique titles.