### PR TITLE
Make display of window buttons in top bar user configurable, fixes #35

### DIFF
--- a/pixel-saver@deadalnix.me/convenience.js
+++ b/pixel-saver@deadalnix.me/convenience.js
@@ -1,0 +1,100 @@
+/* -*- mode:js; indent-tabs-mode:true; tab-width: 4 -*- */
+/*
+  Copyright (c) 2011-2012, Giovanni Campagna <scampa.giovanni@gmail.com>
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the GNOME nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+const Gettext = imports.gettext;
+const Gio = imports.gi.Gio;
+
+const Config = imports.misc.config;
+const ExtensionUtils = imports.misc.extensionUtils;
+
+/**
+ * initTranslations:
+ * @domain: (optional): the gettext domain to use
+ *
+ * Initialize Gettext to load translations from extensionsdir/locale.
+ * If @domain is not provided, it will be taken from metadata['gettext-domain']
+ */
+function initTranslations(domain) {
+	let extension = ExtensionUtils.getCurrentExtension();
+
+	domain = domain || extension.metadata['gettext-domain'];
+
+	log("convenience domain " + domain);
+
+	// check if this extension was built with "make zip-file", and thus
+	// has the locale files in a subfolder
+	// otherwise assume that extension has been installed in the
+	// same prefix as gnome-shell
+	let localeDir = extension.dir.get_child('locale');
+	if (localeDir.query_exists(null)) {
+		log("found " + localeDir.get_path());
+		Gettext.bindtextdomain(domain, localeDir.get_path());
+	} else {
+		log("local " + Config.LOCALEDIR);
+		Gettext.bindtextdomain(domain, Config.LOCALEDIR);
+	}
+}
+
+/**
+ * getSettings:
+ * @schema: (optional): the GSettings schema id
+ *
+ * Builds and return a GSettings schema for @schema, using schema files
+ * in extensionsdir/schemas. If @schema is not provided, it is taken from
+ * metadata['settings-schema'].
+ */
+function getSettings(schema) {
+	let extension = ExtensionUtils.getCurrentExtension();
+
+	schema = schema || extension.metadata['settings-schema'];
+
+	const GioSSS = Gio.SettingsSchemaSource;
+
+	// check if this extension was built with "make zip-file", and thus
+	// has the schema files in a subfolder
+	// otherwise assume that extension has been installed in the
+	// same prefix as gnome-shell (and therefore schemas are available
+	// in the standard folders)
+	let schemaDir = extension.dir.get_child('schemas');
+	let schemaSource;
+	if (schemaDir.query_exists(null)) {
+		schemaSource = GioSSS.new_from_directory(schemaDir.get_path(),
+												 GioSSS.get_default(),
+												 false);
+	} else {
+		schemaSource = GioSSS.get_default();
+	}
+
+	let schemaObj = schemaSource.lookup(schema, true);
+	if (!schemaObj) {
+		throw new Error('Schema ' + schema + ' could not be found for extension '
+			+ extension.metadata.uuid + '. Please check your installation.');
+	}
+
+	return new Gio.Settings({ settings_schema: schemaObj });
+}
+

--- a/pixel-saver@deadalnix.me/extension.js
+++ b/pixel-saver@deadalnix.me/extension.js
@@ -49,15 +49,27 @@ const Me = ExtensionUtils.getCurrentExtension();
 const Decoration = Me.imports.decoration;
 const Buttons = Me.imports.buttons;
 const AppMenu = Me.imports.app_menu;
+const Convenience = Me.imports.convenience; 
+
+const SHOW_BUTTONS = 'show-buttons';
+
+let changedSignal;
+let settings;
 
 function init(extensionMeta) {
+	log("[pixel-saver] init");
 	Buttons.init(extensionMeta);
 	Decoration.init(extensionMeta);
 	AppMenu.init(extensionMeta);
+
+	settings = Convenience.getSettings();
 }
 
 function enable() {
-	Buttons.enable();
+	connectSettings();
+	if (settings.get_boolean(SHOW_BUTTONS)) {
+		Buttons.enable();
+	}
 	Decoration.enable();
 	AppMenu.enable();
 }
@@ -65,6 +77,29 @@ function enable() {
 function disable() {
 	AppMenu.disable();
 	Decoration.disable();
-	Buttons.disable();
+	if (settings.get_boolean(SHOW_BUTTONS)) {
+		Buttons.disable();
+	}
+	disconnectSettings();
+}
+
+function connectSettings() {
+	changedSignal = settings.connect('changed', settingChanged);
+}
+
+function disconnectSettings() {
+	settings.disconnect(changedSignal);
+}
+
+function settingChanged(settings, key) {
+	switch (key) {
+		case SHOW_BUTTONS:
+			if (settings.get_boolean(key)) {
+				Buttons.enable();
+			} else {
+				Buttons.disable();
+			}
+			break;
+	}
 }
 

--- a/pixel-saver@deadalnix.me/makefile
+++ b/pixel-saver@deadalnix.me/makefile
@@ -1,0 +1,77 @@
+UUID = pixel-saver@deadalnix.me
+TOLOCALIZE =  prefs.js
+MSGSRC = $(wildcard po/*.po)
+MODULES = app_menu.js buttons.js convenience.js decoration.js extension.js metadata.json prefs.js util.js
+INSTALLBASE = ~/.local/share/gnome-shell/extensions
+
+all: extension
+
+.PHONY: clean
+clean:
+	-rm -fR ./_build
+	rm -f ./schemas/gschemas.compiled
+	rm -f "$(UUID).zip"
+
+extension: ./schemas/gschemas.compiled $(MSGSRC:.po=.mo)
+
+./schemas/gschemas.compiled: ./schemas/org.gnome.shell.extensions.pixel-saver.gschema.xml
+	glib-compile-schemas ./schemas/
+
+potfile: ./po/pixel-saver.pot
+
+.PHONY: addpo
+addpo:
+ifdef lang
+	msginit --no-translator --locale=$(lang).UTF-8 --output=./po/$(lang).po --input=./po/pixel-saver.pot
+else
+	@echo "You have to specify the language code for the new translation with lang=code\n"
+	@echo "E.g.\n\n    $$ make lang=de\n\n or\n\n    $$ make lang=de_CH\n"
+endif
+
+.PHONY: updatepo
+updatepo: potfile
+	@echo "merge"
+	for l in $(MSGSRC); do \
+		msgmerge -U $$l ./po/pixel-saver.pot; \
+	done;
+
+./po/pixel-saver.pot: $(TOLOCALIZE)
+	@echo "create"
+	mkdir -p po
+	xgettext -k_ -kN_ -o po/pixel-saver.pot --package-name "pixel-saver" $(TOLOCALIZE)
+
+./po/%.mo: ./po/%.po
+	msgfmt -c $< -o $@
+
+install: _build
+	rm -rf $(INSTALLBASE)/$(UUID)
+	mkdir -p $(INSTALLBASE)/$(UUID)
+	cp -r ./_build/* $(INSTALLBASE)/$(UUID)/
+	-rm -fR _build
+
+archive: _build
+	zip -qr "$(UUID).zip" $(MODULES) locale schemas themes
+
+_build: all
+	-rm -fR ./_build
+	mkdir -p _build
+	cp $(MODULES) _build
+	mkdir -p _build/themes
+	cp -r themes/* _build/themes/
+	mkdir -p _build/schemas
+	cp schemas/*.xml _build/schemas/
+	cp schemas/gschemas.compiled _build/schemas/
+	mkdir -p _build/locale
+	for l in $(MSGSRC:.po=.mo) ; do \
+		lf=_build/locale/`basename $$l .mo`; \
+		mkdir -p $$lf; \
+		mkdir -p $$lf/LC_MESSAGES; \
+		cp $$l $$lf/LC_MESSAGES/pixel-saver.mo; \
+	done;
+#	sed -i 's/"version": -1/"version": "$(VERSION)"/'  _build/metadata.json;
+
+#./po/%.mo: ./po/%.po
+#	@echo "format " $@ $< $*
+#	mkdir -p ./locale/$*/LC_MESSAGES
+#	msgfmt -c $< -o ./locale/$*/LC_MESSAGES/pixel-saver.mo
+

--- a/pixel-saver@deadalnix.me/metadata.json
+++ b/pixel-saver@deadalnix.me/metadata.json
@@ -1,1 +1,8 @@
-{"shell-version": ["3.12", "3.14"], "uuid": "pixel-saver@deadalnix.me", "name": "Pixel Saver", "description": "Pixel Saver is designed to save pixel by fusing activity bar and title bar in a natural way"}
+{
+	"uuid": "pixel-saver@deadalnix.me",
+	"name": "Pixel Saver", 
+	"description": "Pixel Saver saves screen real estate by fusing top bar and title bar for maximized windows.",
+	"url": "https://github.com/deadalnix/pixel-saver",
+	"settings-schema": "org.gnome.shell.extensions.pixel-saver",
+	"shell-version": [ "3.12", "3.14" ]
+}

--- a/pixel-saver@deadalnix.me/po/de.po
+++ b/pixel-saver@deadalnix.me/po/de.po
@@ -1,0 +1,22 @@
+# Pixel-saver localization.
+# Copyright (C) 2016 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the pixel-saver package.
+# Marco Hunsicker <pixel-saver@hunsicker.de>, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: pixel-saver\n"
+"Report-Msgid-Bugs-To: https://github.com/deadalnix/pixel-saver/issues\n"
+"POT-Creation-Date: 2016-04-04 21:41+0200\n"
+"PO-Revision-Date: 2016-04-04 21:51+0200\n"
+"Last-Translator: Marco Hunsicker <pixel-saver@hunsicker.de>\n"
+"Language-Team: German\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: prefs.js:31
+msgid "Show window buttons in top bar"
+msgstr "Fensterknöpfe im Panel anzeigen"

--- a/pixel-saver@deadalnix.me/po/pixel-saver.pot
+++ b/pixel-saver@deadalnix.me/po/pixel-saver.pot
@@ -1,0 +1,22 @@
+# pixel-saver localization.
+# Copyright (C) 2016 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the pixel-saver package.
+# Marco Hunsicker, pixel-saver@hunsicker.de, 2006.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: pixel-saver\n"
+"Report-Msgid-Bugs-To: https://github.com/deadalnix/pixel-saver/issues\n"
+"POT-Creation-Date: 2016-04-04 20:20+0200\n"
+"PO-Revision-Date: 2016-04-04 21:00+0200\n"
+"Last-Translator: Marco Hunsicker <pixel-saver@hunsicker.de>\n"
+"Language-Team: English\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: prefs.js:31
+msgid "Show window buttons in top bar"
+msgstr ""

--- a/pixel-saver@deadalnix.me/prefs.js
+++ b/pixel-saver@deadalnix.me/prefs.js
@@ -1,0 +1,52 @@
+/* -*- mode:js; indent-tabs-mode:true; tab-width: 4 -*- */
+const Lang = imports.lang;
+const Gtk = imports.gi.Gtk;
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+const Convenience = Me.imports.convenience;
+
+const Gettext = imports.gettext.domain('pixel-saver');
+const _ = Gettext.gettext;
+
+const SHOW_BUTTONS = 'show-buttons';
+
+function init() {
+	Convenience.initTranslations('pixel-saver');
+}
+
+function buildPrefsWidget() {
+	let settings = Convenience.getSettings();
+
+	let container = new Gtk.Box({
+		orientation: Gtk.Orientation.VERTICAL,
+		border_width: 10
+	});
+
+	(function() {
+		let hbox = new Gtk.Box({
+			orientation: Gtk.Orientation.HORIZONTAL,
+			spacing: 20
+		});
+
+		let showButtonsLabel = new Gtk.Label({
+			label: _("Show window buttons in top bar") + ":"
+		});
+
+		let showButtonsSwitch = new Gtk.Switch({
+			active: settings.get_boolean(SHOW_BUTTONS),
+			halign: Gtk.Align.END
+		});
+		showButtonsSwitch.connect('notify::active', Lang.bind(this, function(src) {
+			settings.set_boolean(SHOW_BUTTONS, src.active);
+		}));
+
+		hbox.add(showButtonsLabel);
+		hbox.pack_end(showButtonsSwitch, true, true, 0);
+
+		container.add(hbox);
+	})();
+
+	container.show_all();
+
+	return container;
+}
+

--- a/pixel-saver@deadalnix.me/schemas/org.gnome.shell.extensions.pixel-saver.gschema.xml
+++ b/pixel-saver@deadalnix.me/schemas/org.gnome.shell.extensions.pixel-saver.gschema.xml
@@ -1,0 +1,9 @@
+<schemalist>
+	<schema id="org.gnome.shell.extensions.pixel-saver" path="/org/gnome/shell/extensions/pixel-saver/">
+		<key name="show-buttons" type="b">
+			<default>true</default>
+			<summary>Shows window buttons in the top bar.</summary>
+			<description>Shows window buttons in the top bar.</description>
+		</key>
+	</schema>
+</schemalist>


### PR DESCRIPTION
Howdy,

as I really like pixel-saver, but can't live with the window buttons in the top bar, I've made the display of the window buttons a user configurable option. This fixes #35.

I'm currently on Debian Jessie and this PR is therefore based on pixel-saver 1.5. It might take some time before I can test against more recent Gnome releases, but maybe this is already enough to get some feedback. I'd think that the code works with more recent releases as well, but the metadata is naturally different.