### PR TITLE
Store original window state to allow cleanup when extension disabled

### DIFF
--- a/pixel-saver@deadalnix.me/decoration.js
+++ b/pixel-saver@deadalnix.me/decoration.js
@@ -109,7 +109,9 @@ function guessWindowXID(win) {
 
 	// debugging for when people find bugs..
 	WARN("Could not find XID for window with title %s".format(win.title));
-	return null;
+
+	// if we can't find an atom, assume the titlebar not to be hidden
+	return win._pixelSaverOriginalState = false;
 }
 
 /**

--- a/pixel-saver@deadalnix.me/decoration.js
+++ b/pixel-saver@deadalnix.me/decoration.js
@@ -164,7 +164,9 @@ function getOriginalState(win) {
 	
 	WARN("Can't find original state for " + win.title + " with id " + id);
 
-	// if we can't find an atom, assume the titlebar not to be hidden
+	// GTK uses the _GTK_HIDE_TITLEBAR_WHEN_MAXIMIZED atom to indicate that the
+	// title bar should be hidden when maximized. If we can't find this atom, the
+	// window uses the default behavior
 	return win._pixelSaverOriginalState = WindowState.DEFAULT;
 }
 


### PR DESCRIPTION
When no atom could be found, this should indicate that the titlebar is not hidden and thus this information should be stored for future reference.

Fixes #63