### PR TITLE
Fixed workspace event cleanup, fixes #66

### DIFF
--- a/pixel-saver@deadalnix.me/decoration.js
+++ b/pixel-saver@deadalnix.me/decoration.js
@@ -341,7 +341,7 @@ function enable() {
 
 function disable() {
 	if (changeWorkspaceID) {
-		global.window_manager.disconnect(changeWorkspaceID);
+		global.screen.disconnect(changeWorkspaceID);
 		changeWorkspaceID = 0;
 	}
 	


### PR DESCRIPTION
This one is trivial. Fixes #66. There is a Glib-GObject warning: `Instance has no handler id` in the log.