### PR TITLE
Make display of window buttons in top bar user configurable

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,0 +1,73 @@
+UUID = pixel-saver@deadalnix.me
+SRC = ./$(UUID)
+TARGET = ./bin
+SCHEMAS = $(TARGET)/schemas/gschemas.compiled
+TOLOCALIZE =  $(SRC)/prefs.js
+MSG_SRC = $(SRC)/po/pixel-saver.pot
+MESSAGES = $(wildcard $(SRC)/po/*.po)
+TRANSLATIONS = $(patsubst $(SRC)/po/%.po,$(TARGET)/locale/%/LC_MESSAGES/pixel-saver.mo, $(wildcard $(SRC)/po/*.po))
+INSTALLBASE = ~/.local/share/gnome-shell/extensions
+
+.SUFFIXES:
+
+all: bin
+
+
+clean:
+	rm -fR $(TARGET)
+
+
+$(TARGET)/schemas/gschemas.compiled: $(SRC)/schemas/org.gnome.shell.extensions.pixel-saver.gschema.xml
+	mkdir -p $(TARGET)/schemas
+	glib-compile-schemas --strict $(SRC)/schemas/ --targetdir=$(TARGET)/schemas
+
+
+$(TARGET)/locale/%/LC_MESSAGES/pixel-saver.mo: $(SRC)/po/%.po
+	mkdir -p $(TARGET)/locale/$*/LC_MESSAGES/
+	msgfmt -c $< -o $@
+
+
+update-po:
+	mkdir -p po
+	xgettext -k_ -kN_ -o $(MSG_SRC) --no-location --copyright-holder "The Pixel Saver team" --package-name "Pixel Saver" --msgid-bugs-address "https://github.com/deadalnix/pixel-saver" $(TOLOCALIZE)
+	@sed -i 's/SOME DESCRIPTIVE TITLE./Pixel Saver Localization/' $(MSG_SRC)
+	@sed -i 's/Copyright (C) YEAR/Copyright (C) 2016/' $(MSG_SRC)
+	@sed -i 's/charset=CHARSET/charset=UTF-8/' $(MSG_SRC)
+	@sed -i 's/PACKAGE package/Pixel Saver package/' $(MSG_SRC)
+	for l in $(MESSAGES); do \
+		msgmerge -U --no-location $$l $(MSG_SRC); \
+	done;
+
+
+add-po:
+ifdef lang
+	msginit --no-translator --locale=$(lang).utf8 --output=$(SRC)/po/$(lang).po --input=$(SRC)/po/pixel-saver.pot
+else
+	@echo "You have to specify the language code for the new translation with lang=code\n"
+	@echo "E.g.\n\n    $$ make addpo lang=de\n\n or\n\n    $$ make addpo lang=de_CH\n"
+endif
+
+
+install: bin uninstall
+	mkdir -p $(INSTALLBASE)/$(UUID)
+	cp -r $(TARGET)/* $(INSTALLBASE)/$(UUID)/
+	-gnome-shell-extension-tool -e $(UUID)
+
+
+uninstall:
+	-@if [ -d $(INSTALLBASE)/$(UUID) ]; then gnome-shell-extension-tool -d $(UUID); fi
+	rm -rf $(INSTALLBASE)/$(UUID)
+
+
+archive: bin
+	cd $(TARGET); zip -qr "$(UUID).zip" *.js metadata.json locale schemas themes
+
+
+bin: $(SCHEMAS) $(TRANSLATIONS)
+	mkdir -p $(TARGET)
+	cp $(SRC)/*.js $(TARGET)
+	cp $(SRC)/metadata.json $(TARGET)
+	cp $(SRC)/schemas/*.xml $(TARGET)/schemas
+	mkdir -p $(TARGET)/themes
+	cp -r $(SRC)/themes/* $(TARGET)/themes/
+

--- a/pixel-saver@deadalnix.me/convenience.js
+++ b/pixel-saver@deadalnix.me/convenience.js
@@ -1,0 +1,96 @@
+/* -*- mode:js; indent-tabs-mode:true; tab-width: 4 -*- */
+/*
+  Copyright (c) 2011-2012, Giovanni Campagna <scampa.giovanni@gmail.com>
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the GNOME nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+const Gettext = imports.gettext;
+const Gio = imports.gi.Gio;
+
+const Config = imports.misc.config;
+const ExtensionUtils = imports.misc.extensionUtils;
+
+/**
+ * initTranslations:
+ * @domain: (optional): the gettext domain to use
+ *
+ * Initialize Gettext to load translations from extensionsdir/locale.
+ * If @domain is not provided, it will be taken from metadata['gettext-domain']
+ */
+function initTranslations(domain) {
+	let extension = ExtensionUtils.getCurrentExtension();
+
+	domain = domain || extension.metadata['gettext-domain'];
+
+	// check if this extension was built with "make zip-file", and thus
+	// has the locale files in a subfolder
+	// otherwise assume that extension has been installed in the
+	// same prefix as gnome-shell
+	let localeDir = extension.dir.get_child('locale');
+	if (localeDir.query_exists(null)) {
+		Gettext.bindtextdomain(domain, localeDir.get_path());
+	} else {
+		Gettext.bindtextdomain(domain, Config.LOCALEDIR);
+	}
+}
+
+/**
+ * getSettings:
+ * @schema: (optional): the GSettings schema id
+ *
+ * Builds and return a GSettings schema for @schema, using schema files
+ * in extensionsdir/schemas. If @schema is not provided, it is taken from
+ * metadata['settings-schema'].
+ */
+function getSettings(schema) {
+	let extension = ExtensionUtils.getCurrentExtension();
+
+	schema = schema || extension.metadata['settings-schema'];
+
+	const GioSSS = Gio.SettingsSchemaSource;
+
+	// check if this extension was built with "make zip-file", and thus
+	// has the schema files in a subfolder
+	// otherwise assume that extension has been installed in the
+	// same prefix as gnome-shell (and therefore schemas are available
+	// in the standard folders)
+	let schemaDir = extension.dir.get_child('schemas');
+	let schemaSource;
+	if (schemaDir.query_exists(null)) {
+		schemaSource = GioSSS.new_from_directory(schemaDir.get_path(),
+												 GioSSS.get_default(),
+												 false);
+	} else {
+		schemaSource = GioSSS.get_default();
+	}
+
+	let schemaObj = schemaSource.lookup(schema, true);
+	if (!schemaObj) {
+		throw new Error('Schema ' + schema + ' could not be found for extension '
+			+ extension.metadata.uuid + '. Please check your installation.');
+	}
+
+	return new Gio.Settings({ settings_schema: schemaObj });
+}
+

--- a/pixel-saver@deadalnix.me/metadata.json
+++ b/pixel-saver@deadalnix.me/metadata.json
@@ -3,5 +3,6 @@
 	"name": "Pixel Saver",
 	"description": "Pixel Saver is designed to save pixel by fusing activity bar and title bar in a natural way",
 	"url": "https://github.com/deadalnix/pixel-saver",
+	"settings-schema": "org.gnome.shell.extensions.pixel-saver",
 	"shell-version": ["3.16", "3.18", "3.20"]
 }

--- a/pixel-saver@deadalnix.me/prefs.js
+++ b/pixel-saver@deadalnix.me/prefs.js
@@ -1,0 +1,67 @@
+/* -*- mode:js; indent-tabs-mode:true; tab-width:2; -*- */
+const GObject = imports.gi.GObject;
+const Gtk = imports.gi.Gtk;
+const Lang = imports.lang;
+
+const Gettext = imports.gettext.domain('pixel-saver');
+const _ = Gettext.gettext;
+
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+const Convenience = Me.imports.convenience;
+const Settings = Me.imports.settings;
+
+function init() {
+	Convenience.initTranslations('pixel-saver');
+}
+
+function column(label, widget) {
+	let box = new Gtk.Box({
+		orientation: Gtk.Orientation.HORIZONTAL,
+		spacing: 18
+	});
+	box.add(label);
+	box.pack_end(widget, true, true, 0);
+
+	return box;
+}
+
+const PixelSaverPrefsWidget = new GObject.Class({
+	Name: 'PixelSaver.Prefs.Widget',
+	GTypeName: 'PixelSaverPrefsWidget',
+	Extends: Gtk.Box,
+
+	_init: function(params) {
+		this.parent(params);
+
+		this.orientation = Gtk.Orientation.VERTICAL;
+		this.border_width = 18;
+		this.spacing = 6;
+
+		let options = new Settings.Options();
+
+		let buttonPositionLabel = new Gtk.Label({
+			label: _("Show window buttons in top panel"),
+		});
+
+		let buttonPositionCombo = new Gtk.ComboBoxText({ halign:Gtk.Align.END });
+		buttonPositionCombo.set_size_request(120, -1);
+		buttonPositionCombo.append('before-name', _("Before Application Name"));
+		buttonPositionCombo.append('after-name', _("After Application Name"));
+		buttonPositionCombo.append('within-status-area', _("Within System Status Area"));
+		buttonPositionCombo.append('after-status-area', _("After System Status Area"));
+		buttonPositionCombo.append('hidden', _("Don't show"));
+		buttonPositionCombo.set_active_id(options.BUTTON_POSITION.get());
+		buttonPositionCombo.connect('changed', Lang.bind(this, function(widget) {
+			options.BUTTON_POSITION.set(widget.get_active_id());
+		}));
+
+		this.add(column(buttonPositionLabel, buttonPositionCombo));
+	}
+});
+
+function buildPrefsWidget() {
+	let widget = new PixelSaverPrefsWidget();
+	widget.show_all();
+	return widget;
+}
+

--- a/pixel-saver@deadalnix.me/schemas/org.gnome.shell.extensions.pixel-saver.gschema.xml
+++ b/pixel-saver@deadalnix.me/schemas/org.gnome.shell.extensions.pixel-saver.gschema.xml
@@ -1,0 +1,17 @@
+<schemalist>
+	<enum id="org.gnome.shell.extensions.pixel-saver.buttonPosition">
+		<value value="0" nick="before-name" />
+		<value value="1" nick="after-name" />
+		<value value="2" nick="within-status-area" />
+		<value value="3" nick="after-status-area" />
+		<value value="4" nick="hidden" />
+	</enum>
+	<schema id="org.gnome.shell.extensions.pixel-saver" path="/org/gnome/shell/extensions/pixel-saver/">
+		<key enum="org.gnome.shell.extensions.pixel-saver.buttonPosition" name="button-position">
+			<default>'within-status-area'</default>
+			<summary>Button position in the top panel</summary>
+			<description>Controls whether and where buttons of maximized windows appear in the top panel. Possible values are: "before-name" to display buttons before the application name, "after-name" to display buttons after the application name, "within-status-area" to display buttons within the system status area, "after-status-area" to display buttons after the system status area and "hidden" to not show buttons at all.
+			</description>
+		</key>
+	</schema>
+</schemalist>

--- a/pixel-saver@deadalnix.me/settings.js
+++ b/pixel-saver@deadalnix.me/settings.js
@@ -1,0 +1,29 @@
+/* -*- mode:js; indent-tabs-mode:true; tab-width:2 -*- */
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+const Convenience = Me.imports.convenience;
+
+function Options() {
+	var self = this;
+	var settings = Convenience.getSettings();
+	var signals = {};
+	function _bind(key, callback) {
+		return signals[key] = settings.connect('changed::' + key, callback);
+	};
+	this.BUTTON_POSITION = {
+		key: 'button-position',
+		get: function() { return settings.get_string(this.key); },
+		set: function(value) { settings.set_string(this.key, value); },
+		changed: function(callback) {
+			return _bind(this.key, callback);
+		},
+	};
+	this.destroy = function() {
+		for (var key in signals) {
+			if (signals.hasOwnProperty(key)) {
+				settings.disconnect(signals[key]);
+				delete signals[key];
+			}
+		}
+	};
+}
+


### PR DESCRIPTION
I had some problems with git and reset master. As a consequence the other PR for this vanished. Sorry for that.

Here is another one that provides the same, minus localization, but plus the extended set of button position options. Tested on 3.18.

Tab width has been set to '2'. I assume this is your preference?

fixes #35 
fixes #46