### PR TITLE
Update decoration.js to remove a warning

### DIFF
--- a/pixel-saver@deadalnix.me/decoration.js
+++ b/pixel-saver@deadalnix.me/decoration.js
@@ -253,7 +253,7 @@ function onWindowAdded(ws, win, retry) {
 		return false;
 	}
 	
-	let retry = 3;
+	retry = 3;
 	Mainloop.idle_add(function () {
 		let id = guessWindowXID(win);
 		if (!id) {


### PR DESCRIPTION
Just to remove this warning:

Gjs-Message: JS WARNING: [~/.local/share/gnome-shell/extensions/pixel-saver@deadalnix.me/decoration.js 256]: variable retry redeclares argument