### PR TITLE
Remove warning about return value of anonymous function

### DIFF
--- a/pixel-saver@deadalnix.me/buttons.js
+++ b/pixel-saver@deadalnix.me/buttons.js
@@ -105,7 +105,7 @@ function destroyButtons() {
 function leftclick(callback) {
 	return function(actor, event) {
 		if (event.get_button() !== 1) {
-			return;
+			return null;
 		}
 		
 		return callback(actor, event);


### PR DESCRIPTION
Hi,

Using:

```sh
gnome-shell --replace &
```

I've got the following:

```sh
Gjs-Message: JS WARNING: [/home/zapashcanon/.local/share/gnome-shell/extensions/pixel-saver@deadalnix.me/buttons.js 111]: anonymous function does not always return a value
```

This change fix the warning.

My editor also made a lot of whitespace changes, I don't know if it's a problem, if it is, tell me and I'll remove them. ;)

Thanks !