### PR TITLE
Move buttons to AppMenu and link them to focused window

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@ The extension has no configuration. Its behavior is made to mimic the one of
 the title bar and settings affecting the title bar should reflect in
 Pixel Saver. It **Just Works** !
 
-For applications using the modern GTK header bar, there are no space savings,
-but the application title is still displayed in the top panel to achieve a
-uniform appearance.
+For applications using the modern GTK header bar there are no space savings, as
+the header bar can contain custom functionality.
 
 <table>
 	<tr>

--- a/pixel-saver@deadalnix.me/app_menu.js
+++ b/pixel-saver@deadalnix.me/app_menu.js
@@ -30,8 +30,7 @@ function updateAppMenu() {
 	
 	let title = win.title;
 	
-	// Not the topmost maximized window.
-	if (win !== Util.getWindow()) {
+	if (!(win.decorated && win.get_maximized())) {
 		let app = Shell.WindowTracker.get_default().get_window_app(win);
 		title = app.get_name();
 	}

--- a/pixel-saver@deadalnix.me/buttons.js
+++ b/pixel-saver@deadalnix.me/buttons.js
@@ -82,16 +82,16 @@ function createButtons() {
 	}
 	
 	Mainloop.idle_add(function () {
+		let buttonContainer = Main.panel.statusArea.appMenu._label.get_parent();
 		// 1 for activity button and -1 for the menu
 		if (boxes[0].get_children().length) {
-			Main.panel._leftBox.insert_child_at_index(actors[0], 1);
+			buttonContainer.insert_child_at_index(actors[0], 0);
 		}
 		
 		if (boxes[1].get_children().length) {
-			Main.panel._rightBox.insert_child_at_index(actors[1], Main.panel._rightBox.get_children().length - 1);
+			buttonContainer.insert_child_at_index(actors[1], buttonContainer.get_children().length - 1);
 		}
 		
-		updateVisibility();
 		return false;
 	});
 }
@@ -120,7 +120,7 @@ function leftclick(callback) {
 }
 
 function minimize() {
-	let win = Util.getWindow();
+	let win = global.display.focus_window;
 	if (!win || win.minimized) {
 		WARN('impossible to minimize');
 		return;
@@ -130,7 +130,7 @@ function minimize() {
 }
 
 function maximize() {
-	let win = Util.getWindow();
+	let win = global.display.focus_window;
 	if (!win) {
 		WARN('impossible to maximize');
 		return;
@@ -148,7 +148,7 @@ function maximize() {
 }
 
 function close() {
-	let win = Util.getWindow();
+	let win = global.display.focus_window;
 	if (!win) {
 		WARN('impossible to close');
 		return;
@@ -199,35 +199,6 @@ function unloadTheme() {
 }
 
 /**
- * callbacks
- */
-function updateVisibility() {
-	// If we have a window to control, then we show the buttons.
-	let visible = !Main.overview.visible;
-	if (visible) {
-		visible = false;
-		let win = Util.getWindow();
-		if (win) {
-			visible = win.decorated;
-		}
-	}
-	
-	actors.forEach(function(actor, i) {
-		if (!boxes[i].get_children().length) {
-			return;
-		}
-		
-		if (visible) {
-			actor.show();
-		} else {
-			actor.hide();
-		}
-	});
-	
-	return false;
-}
-
-/**
  * Subextension hooks
  */
 let extensionPath;
@@ -235,40 +206,16 @@ function init(extensionMeta) {
 	extensionPath = extensionMeta.path;
 }
 
-let wmCallbackIDs = [];
-let overviewCallbackIDs = [];
 let themeCallbackID = 0;
 
 function enable() {
 	loadTheme();
 	createButtons();
-	
-	overviewCallbackIDs.push(Main.overview.connect('showing', updateVisibility));
-	overviewCallbackIDs.push(Main.overview.connect('hidden', updateVisibility));
-	
-	let wm = global.window_manager;
-	wmCallbackIDs.push(wm.connect('switch-workspace', updateVisibility));
-	wmCallbackIDs.push(wm.connect('map', updateVisibility));
-	wmCallbackIDs.push(wm.connect('minimize', updateVisibility));
-	wmCallbackIDs.push(wm.connect('unminimize', updateVisibility));
-	
-	wmCallbackIDs = wmCallbackIDs.concat(Util.onSizeChange(updateVisibility));
-	
+
 	themeCallbackID = Gtk.Settings.get_default().connect('notify::gtk-theme-name', loadTheme);
 }
 
 function disable() {
-	wmCallbackIDs.forEach(function(id) {
-		global.window_manager.disconnect(id);
-	});
-	
-	overviewCallbackIDs.forEach(function(id) {
-		Main.overview.disconnect(id);
-	});
-	
-	wmCallbackIDs = [];
-	overviewCallbackIDs = [];
-	
 	if (themeCallbackID !== 0) {
 		Gtk.Settings.get_default().disconnect(0);
 		themeCallbackID = 0;

--- a/pixel-saver@deadalnix.me/util.js
+++ b/pixel-saver@deadalnix.me/util.js
@@ -1,26 +1,4 @@
 const Mainloop = imports.mainloop;
-const Meta = imports.gi.Meta;
-
-const MAXIMIZED = Meta.MaximizeFlags.BOTH;
-
-function getWindow() {
-	// get all window in stacking order.
-	let windows = global.display.sort_windows_by_stacking(
-		global.screen.get_active_workspace().list_windows().filter(function (w) {
-			return w.get_window_type() !== Meta.WindowType.DESKTOP;
-		})
-	);
-	
-	let i = windows.length;
-	while (i--) {
-		let window = windows[i];
-		if (window.get_maximized() === MAXIMIZED && !window.minimized) {
-			return window;
-		}
-	}
-	
-	return null;
-}
 
 function onSizeChange(callback) {
 	let callbackIDs = [];


### PR DESCRIPTION
This branch changes the behaviour of the buttons to always be linked to the focused window, and display them with the AppMenu.

This makes it more clear what the buttons do, and make it more logical to work with partially (e.g. only vertical) maximised windows. (if you had two vertically maximised windows you couldn't say what window would be closed)

Issue #49 is also related to this. Also #30 is fixed.

I don't know if you want to go in this direction, but I'm quite satisfied with it, so please test it and see what you think.

