### PR TITLE
Fix gnome-shell error when label is null

### DIFF
--- a/pixel-saver@deadalnix.me/app_menu.js
+++ b/pixel-saver@deadalnix.me/app_menu.js
@@ -124,7 +124,7 @@ function onAppMenuHover(actor) {
 			}
 			
 			let label = appMenu._label;
-			if (!label.get_clutter_text().get_layout().is_ellipsized()) {
+			if (label == null || !label.get_clutter_text().get_layout().is_ellipsized()) {
 				// Do not need to hide.
 				tooltipDelayCallbackID = 0;
 				return false;


### PR DESCRIPTION
Hi,

Running: `gnome-shell --replace &` I had this:

```sh
(gnome-shell:2257): Gjs-WARNING **: JS ERROR: TypeError: label is undefined
onAppMenuHover/tooltipDelayCallbackID<@/home/zapashcanon/.local/share/gnome-shell/extensions/pixel-saver@deadalnix.me/app_menu.js:127

(gnome-shell:2257): GLib-CRITICAL **: Source ID 46403 was not found when attempting to remove it

(gnome-shell:2257): Clutter-WARNING **: Attempting to remove actor of type 'StLabel' from group of class 'ShellGenericContainer', but the container is not the actor's parent.
```

This commit seems to fix this.