### PR TITLE
Increased margin between tooltip and panel

### DIFF
--- a/pixel-saver@deadalnix.me/app_menu.js
+++ b/pixel-saver@deadalnix.me/app_menu.js
@@ -141,10 +141,11 @@ function onAppMenuHover(actor) {
 				}
 			});
 			
+			[px, py] = Main.panel.actor.get_transformed_position();
 			[bx, by] = label.get_transformed_position();
 			[w, h] = label.get_transformed_size();
 			
-			let y = by + h + 10;
+			let y = py + Main.panel.actor.get_height() + 3;
 			let x = bx - Math.round((tooltip.get_width() - w)/2);
 			tooltip.opacity = 0;
 			tooltip.set_position(x, y);

--- a/pixel-saver@deadalnix.me/app_menu.js
+++ b/pixel-saver@deadalnix.me/app_menu.js
@@ -144,7 +144,7 @@ function onAppMenuHover(actor) {
 			[bx, by] = label.get_transformed_position();
 			[w, h] = label.get_transformed_size();
 			
-			let y = by + h + 5;
+			let y = by + h + 10;
 			let x = bx - Math.round((tooltip.get_width() - w)/2);
 			tooltip.opacity = 0;
 			tooltip.set_position(x, y);


### PR DESCRIPTION
Tooltip looks nicer when there is a small margin from panel:

**before**
![before](https://cloud.githubusercontent.com/assets/6562863/21659461/3f2a7b08-d2e4-11e6-8409-a34370790976.png)

**after**
![after](https://cloud.githubusercontent.com/assets/6562863/21659473/4a61f424-d2e4-11e6-91bb-b4cafa5d72e9.png)