### PR TITLE
Window controls for left/right snapped windows

### DIFF
--- a/pixel-saver@deadalnix.me/util.js
+++ b/pixel-saver@deadalnix.me/util.js
@@ -2,6 +2,7 @@ const Mainloop = imports.mainloop;
 const Meta = imports.gi.Meta;
 
 const MAXIMIZED = Meta.MaximizeFlags.BOTH;
+const VMAXIMIZED = Meta.MaximizeFlags.VERTICAL;
 
 function getWindow() {
 	// get all window in stacking order.
@@ -14,7 +15,7 @@ function getWindow() {
 	let i = windows.length;
 	while (i--) {
 		let window = windows[i];
-		if (window.get_maximized() === MAXIMIZED && !window.minimized) {
+		if (window.get_maximized() === MAXIMIZED || VMAXIMIZED && !window.minimized) {
 			return window;
 		}
 	}


### PR DESCRIPTION
This small change makes the window controls display in the extension when a window is vertically maximized but not full maximized (i.e. when the window is snapped to the left or right). Currently, the pixel saver controls only display for fully maximized windows and this can create a problem for snapped window control.