### PR TITLE
update install instructions to reference tag 1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can also follow these simply instruction for manual installation :
     git clone https://github.com/deadalnix/pixel-saver.git
     cd pixel-saver
     # Get the last released version
-	git checkout 1.9
+	git checkout 1.10
     # copy to extensions directory
     cp -r pixel-saver@deadalnix.me -t ~/.local/share/gnome-shell/extensions
     # activate


### PR DESCRIPTION
I just upgraded to Fedora 26 which includes GNOME 2.24 and stumbled a bit when the pixel-saver instructions suggested tag 1.9.  Once I installed tag 1.10, things started working.

Thanks for this fantastic extension, it's one of my favorites!