### PR TITLE
Handles empty button-layout value

### DIFF
--- a/pixel-saver@deadalnix.me/buttons.js
+++ b/pixel-saver@deadalnix.me/buttons.js
@@ -45,6 +45,11 @@ function createButtons() {
 	let order = new Gio.Settings({schema_id: DCONF_META_PATH}).get_string('button-layout');
 	LOG('Buttons layout : ' + order);
 	
+	if (order.indexOf(':') == -1) {
+		LOG('Button layout empty')
+		return
+	}
+	
 	let orders = order.replace(/ /g, '').split(':');
 	
 	orders[0] = orders[0].split(',');


### PR DESCRIPTION
Handles the situation where the value of the key button-layout has been
set to empty string. In this situation the split on : will result in an
array of size 1, which subsequental causes the code to error, as it
assumes there to be at least indexes 0 and 1.