### PR TITLE
Move windows buttons to right of panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Pixel Saver is an extension for Gnome Shell that merge the activity bar and the
 title bar of maximized window. It is especially interesting for small screens,
 but MOAR pixels for your apps is always good !
 
+This repo is forked form the original by deadalnix, and has some fixes merged into it since deadalnix became unresponsive.
+
 The extension has no configuration. Its behavior is made to mimic the one of
 the title bar and settings affecting the title bar should reflect in
 Pixel Saver. It **Just Works** !

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Install it with one click from the [GNOME extension repository](https://extensio
 
 You can also follow these simple instructions for manual installation :
 
-    git clone https://github.com/deadalnix/pixel-saver.git
+    git clone https://github.com/JensTimmerman/pixel-saver.git
     cd pixel-saver
     # Get the last released version
 	git checkout 1.10

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ You can also follow these simple instructions for manual installation :
 
     git clone https://github.com/JensTimmerman/pixel-saver.git
     cd pixel-saver
-    # Get the last released version
-	git checkout 1.10
+    # Get the last bleeding edge version, the last official release is in original deadalnix fork.
+	git checkout master
     # copy to extensions directory
     cp -r pixel-saver@deadalnix.me -t ~/.local/share/gnome-shell/extensions
     # activate

--- a/pixel-saver@deadalnix.me/app_menu.js
+++ b/pixel-saver@deadalnix.me/app_menu.js
@@ -36,6 +36,7 @@ function updateAppMenu() {
 		title = app.get_name();
 	}
 	
+	title = title.replace(/\n/g, " ");
 	LOG('Override title ' + title);
 	appMenu._label.set_text(title);
 	tooltip.text = title;

--- a/pixel-saver@deadalnix.me/buttons.js
+++ b/pixel-saver@deadalnix.me/buttons.js
@@ -45,7 +45,7 @@ function createButtons() {
 	let order = new Gio.Settings({schema_id: DCONF_META_PATH}).get_string('button-layout');
 	LOG('Buttons layout : ' + order);
 	
-	if (order.indexOf(':') == -1) {
+	if (order.indexOf(':') == -1 && order.length <= 1) {
 		LOG('Button layout empty')
 		return
 	}

--- a/pixel-saver@deadalnix.me/buttons.js
+++ b/pixel-saver@deadalnix.me/buttons.js
@@ -225,8 +225,8 @@ function updateVisibility() {
 			return;
 		}
 		
-		if (visible) {
-			actor.show();
+	   	if (visible) {
+	        	actor.show();
 		} else {
 			actor.hide();
 		}
@@ -246,6 +246,7 @@ function init(extensionMeta) {
 let wmCallbackIDs = [];
 let overviewCallbackIDs = [];
 let themeCallbackID = 0;
+let focusCallbackID = 0;
 
 function enable() {
 	loadTheme();
@@ -263,6 +264,8 @@ function enable() {
 	wmCallbackIDs = wmCallbackIDs.concat(Util.onSizeChange(updateVisibility));
 	
 	themeCallbackID = Gtk.Settings.get_default().connect('notify::gtk-theme-name', loadTheme);
+
+ 	focusCallbackID = global.display.connect('notify::focus-window', updateVisibility);
 }
 
 function disable() {
@@ -277,6 +280,9 @@ function disable() {
 	wmCallbackIDs = [];
 	overviewCallbackIDs = [];
 	
+	global.display.disconnect(focusCallbackID);
+	focusCallbackID = 0;
+
 	if (themeCallbackID !== 0) {
 		Gtk.Settings.get_default().disconnect(0);
 		themeCallbackID = 0;

--- a/pixel-saver@deadalnix.me/extension.js
+++ b/pixel-saver@deadalnix.me/extension.js
@@ -43,6 +43,11 @@
  * [5]:http://www.webupd8.org/2011/05/how-to-remove-maximized-windows.html
  *
  */
+
+global.workspace = function() {
+  global.screen ? global.screen : global.workspace_manager;
+}
+
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const Decoration = Me.imports.decoration;

--- a/pixel-saver@deadalnix.me/extension.js
+++ b/pixel-saver@deadalnix.me/extension.js
@@ -5,8 +5,12 @@
  * Other contributors:
  * - Amy Chan <mathematical.coffee@gmail.com>
  * Sept-- 2013.
+ * forked by Jens Timmerman <jens.timmerman@gmail.com>
+ * Feb-- 2019.
  *
  * ## Help! It didn't work/I found a bug!
+ * This is not the original plugin, but a fork for gnome shell 3.30 with some extra fixes
+ * the code is found at https://github.com/JensTimmerman/pixel-saver
  *
  * This extension is based on work by Amy Chan, namely maximus[1] and Window Buttons[2].
  *

--- a/pixel-saver@deadalnix.me/metadata.json
+++ b/pixel-saver@deadalnix.me/metadata.json
@@ -1,7 +1,7 @@
 {
-	"uuid": "pixel-saver@deadalnix.me",
-	"name": "Pixel Saver",
-	"description": "Pixel Saver is designed to save pixel by fusing activity bar and title bar in a natural way",
-	"url": "https://github.com/deadalnix/pixel-saver",
-	"shell-version": ["3.18", "3.20", "3.22", "3.24", "3.26"]
+	"uuid": "pixel-saver@jensti.local",
+	"name": "Pixel Saver fork",
+	"description": "Pixel Saver is designed to save pixel by fusing activity bar and title bar in a natural way, This is a fork from the original",
+	"url": "https://github.com/jenstimmerman/pixel-saver",
+	"shell-version": ["3.30", "3.18", "3.20", "3.22", "3.24", "3.26"]
 }

--- a/pixel-saver@deadalnix.me/util.js
+++ b/pixel-saver@deadalnix.me/util.js
@@ -28,7 +28,11 @@ function getWindow() {
 	let i = windows.length;
 	while (i--) {
 		let window = windows[i];
-		if (window.get_maximized() === MAXIMIZED && !window.minimized) {
+	        let is_maximized = window.get_maximized() === MAXIMIZED;
+	        // half maximized
+  	        let is_maxvertical = window.get_maximized() === Meta.MaximizeFlags.VERTICAL;
+	        // window.has_focus() get the focused window
+		if (window.has_focus() && (is_maximized || is_maxvertical)  && !window.minimized) {
 			return window;
 		}
 	}


### PR DESCRIPTION
Is there any way to modify the position of the buttons of the window to the right of the panel?
![request](https://user-images.githubusercontent.com/30301383/55677477-bed26200-58be-11e9-96aa-ba36b2fd4cac.png)
